### PR TITLE
Fix reverse speed bug and improve collision

### DIFF
--- a/src/models/game.js
+++ b/src/models/game.js
@@ -147,8 +147,12 @@
       for (var j = i + 1; j < allCollidableObjects.length; j++) {
         var ufo2 = allCollidableObjects[j];
         if (this.isColliding(ufo1, ufo2)) {
-          ufo1.hp -= 5;
-          ufo2.hp -= 5;
+          ufo1.hp -= 1;
+          ufo2.hp -= 1;
+          ufo1.dx *= (1/10);
+          ufo1.dy *= (1/10);
+          ufo2.dx *= (1/10);
+          ufo2.dy *= (1/10);
         }
       }
     }

--- a/src/models/ship.js
+++ b/src/models/ship.js
@@ -44,13 +44,14 @@
   //function responds to booleans set by player keystrokes. Controls thrust, brake, and rotation of ship.
   Ship.prototype.navigateTheStars = function() {
     if (this.keys.up === true) {
-      if (this.speed() < this.maxSpeed) {
-        this.dx += this.thrust * Math.cos(this.rad);
-        this.dy += this.thrust * Math.sin(this.rad);
-      } else {
+      this.dx += this.thrust * Math.cos(this.rad);
+      this.dy += this.thrust * Math.sin(this.rad);
+
+      if (this.speed() > this.maxSpeed) {
         var newdx = this.dx + this.thrust * Math.cos(this.rad);
         var newdy = this.dy + this.thrust * Math.sin(this.rad);
         var newRad = Math.atan2(newdy, newdx);
+        
         this.dx = this.maxSpeed * Math.cos(newRad);
         this.dy = this.maxSpeed * Math.sin(newRad);
       }


### PR DESCRIPTION
Fix reverse speed bug by adjusting back to max speed after applying acceleration.
Improve collision by stopping both object when they collide. Avoids high HP items from penetrating each other.